### PR TITLE
[EC-177] Add health checks and fast-fail

### DIFF
--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -26,6 +26,6 @@ COPY obj/build-output/publish .
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
-HEALTHCHECK CMD curl -f http://localhost:5000/alive || exit 1
+HEALTHCHECK CMD curl -f http://localhost:5000/health || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/KeyConnector/Services/CryptoService.cs
+++ b/src/KeyConnector/Services/CryptoService.cs
@@ -107,10 +107,13 @@ namespace Bit.KeyConnector.Services
                 }
                 else
                 {
-                    _symmetricKey = await _cryptoFunctionService.GetRandomBytesAsync(32);
+                    var newSymmetricKey = await _cryptoFunctionService.GetRandomBytesAsync(32);
                     var decodedEncKey = await RsaEncryptAsync(_symmetricKey);
                     encKey = Convert.ToBase64String(decodedEncKey);
                     await _applicationDataRepository.UpdateSymmetricKeyAsync(encKey);
+
+                    // Only save in memory after successfully saving to database
+                    _symmetricKey = newSymmetricKey;
                 }
             }
 

--- a/src/KeyConnector/Services/RsaHealthCheckService.cs
+++ b/src/KeyConnector/Services/RsaHealthCheckService.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Bit.KeyConnector.Services
+{
+    public class RsaHealthCheckService : IHealthCheck
+    {
+        private IRsaKeyService _rsaKeyService;
+
+        public RsaHealthCheckService(IRsaKeyService rsaKeyService)
+        {
+            _rsaKeyService = rsaKeyService;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            var publicKey = await _rsaKeyService.GetPublicKeyAsync();
+
+            return publicKey != null
+                ? HealthCheckResult.Healthy("Healthy")
+                : HealthCheckResult.Unhealthy("Unhealthy");
+        }
+    }
+}

--- a/src/KeyConnector/Startup.cs
+++ b/src/KeyConnector/Startup.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Serilog;
 
 namespace Bit.KeyConnector
@@ -52,6 +53,9 @@ namespace Bit.KeyConnector
             {
                 services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
             }
+
+            services.AddHealthChecks()
+                .AddCheck<RsaHealthCheckService>("RsaHealthCheckService");
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, KeyConnectorSettings settings)
@@ -69,7 +73,10 @@ namespace Bit.KeyConnector
             app.UseAuthentication();
             app.UseAuthorization();
 
-            app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+            app.UseEndpoints(endpoints => {
+                endpoints.MapDefaultControllerRoute();
+                endpoints.MapHealthChecks("~/health").AllowAnonymous();
+            });
         }
 
         private bool AddDatabase(IServiceCollection services, KeyConnectorSettings settings)


### PR DESCRIPTION
## Objective

* add a health check endpoint at `/health`. Currently this will just check that the RSA key can be successfully accessed and loaded. It returns a simple "Healthy" or "Unhealthy" result, but it should be enough to prompt the user to check logs. This endpoint is used by Docker to report on the container health as well, so the result will show in `docker container ls`.
* only save a new encKey in memory _after_ saving to database, as a preventative measure in case we have issues with saving it

We discussed making the application terminate if the health check fails on start, but I didn't think that was necessary. With these changes, there is better reporting back to the user, and Key Connector simply won't work if the RSA key cannot be loaded. (Although I can still add this in if required.)