### PR TITLE
[EC-178] Fix RSA encrypt for newSymmetricKey, add null check

### DIFF
--- a/src/KeyConnector/Services/CryptoService.cs
+++ b/src/KeyConnector/Services/CryptoService.cs
@@ -109,6 +109,12 @@ namespace Bit.KeyConnector.Services
                 {
                     var newSymmetricKey = await _cryptoFunctionService.GetRandomBytesAsync(32);
                     var decodedEncKey = await RsaEncryptAsync(_symmetricKey);
+
+                    if (decodedEncKey == null)
+                    {
+                        throw new Exception("RSA encryption failed. Your RSA key may not be configured properly.");
+                    }
+
                     encKey = Convert.ToBase64String(decodedEncKey);
                     await _applicationDataRepository.UpdateSymmetricKeyAsync(encKey);
 

--- a/src/KeyConnector/Services/CryptoService.cs
+++ b/src/KeyConnector/Services/CryptoService.cs
@@ -108,7 +108,7 @@ namespace Bit.KeyConnector.Services
                 else
                 {
                     var newSymmetricKey = await _cryptoFunctionService.GetRandomBytesAsync(32);
-                    var decodedEncKey = await RsaEncryptAsync(_symmetricKey);
+                    var decodedEncKey = await RsaEncryptAsync(newSymmetricKey);
 
                     if (decodedEncKey == null)
                     {


### PR DESCRIPTION
## Objective
Follow-on from https://github.com/bitwarden/key-connector/pull/16.

* update variable name, we need to encrypt `newSymmetricKey`, not `_symmetricKey` (which is still null)
* if the RSA encryption fails, it can return null and then you get a cryptic B64 error. Instead, add null check and throw a more helpful error.