### PR TITLE
Update internal Uris to match self-hosted dev settings

### DIFF
--- a/src/KeyConnector/appsettings.Development.json
+++ b/src/KeyConnector/appsettings.Development.json
@@ -14,7 +14,7 @@
     ]
   },
   "keyConnectorSettings": {
-    "webVaultUri": "https://localhost:8080/",
-    "identityServerUri": "http://localhost:33656/"
+    "webVaultUri": "https://localhost:8081/",
+    "identityServerUri": "http://localhost:33657/"
   }
 }


### PR DESCRIPTION
## Objective

Update the Key Connector default development settings to match the ports that we use for self-hosted development.

Key Connector only works for self-hosted instances, so there didn't seem any point in creating a separate launch profile like we have for server.