### PR TITLE
Disable DCT for Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,16 +66,15 @@ jobs:
           echo "GitHub event: $GITHUB_EVENT"
           echo "Github Release Option: $_RELEASE_OPTION"
 
-      - name: Setup DCT
-        id: setup-dct
-        uses: bitwarden/gh-actions/setup-docker-trust@a8c384a05a974c05c48374c818b004be221d43ff
-        with:
-          azure-creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
-          azure-keyvault-name: "bitwarden-prod-kv"
+      # - name: Setup DCT
+      #   id: setup-dct
+      #   uses: bitwarden/gh-actions/setup-docker-trust@a8c384a05a974c05c48374c818b004be221d43ff
+      #   with:
+      #     azure-creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+      #     azure-keyvault-name: "bitwarden-prod-kv"
 
       - name: Checkout repo
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579  # v2.4.0
-
 
       - name: Pull latest selfhost image
         run: |
@@ -99,9 +98,9 @@ jobs:
 
       - name: Push version and latest image
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
-        env:
-          DOCKER_CONTENT_TRUST: 1
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
+        # env:
+        #   DOCKER_CONTENT_TRUST: 1
+        #   DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ steps.setup-dct.outputs.dct-delegate-repo-passphrase }}
         run: |
           docker push bitwarden/$_SERVICE_NAME:$_RELEASE_VERSION
           docker push bitwarden/$_SERVICE_NAME:latest


### PR DESCRIPTION
This PR disables DCT in the `release` workflow since we never set it up fully.