### PR TITLE
Update deprecated Azure Key Vault in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,11 +161,18 @@ jobs:
 
       - name: Retrieve secrets
         id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@64af23c7cf243996cd6ec3b15a6957947935c54b  # v1
         if: failure()
-        with:
-          keyvault: "bitwarden-prod-kv"
-          secrets: "devops-alerts-slack-webhook-url"
+        env:
+          KEYVAULT: bitwarden-prod-kv
+          SECRETS: |
+            devops-alerts-slack-webhook-url
+        run: |
+          for i in ${SECRETS//,/ }
+          do
+            VALUE=$(az keyvault secret show --vault-name $KEYVAULT --name $i --query value --output tsv)
+            echo "::add-mask::$VALUE"
+            echo "::set-output name=$i::$VALUE"
+          done
 
       - name: Notify Slack on failure
         uses: act10ns/slack@da3191ebe2e67f49b46880b4633f5591a96d1d33  # v1.5.1


### PR DESCRIPTION
The GitHub action Azure Key Vault is being deprecated and will no longer be maintained. The outcome of the related spike offers a solution to implement as a drop-in replacement using bash and the Az CLI. All references for the `Azure/get-keyvault-secrets` action will need to be replaced with this bash step in all our workflows.