### PR TITLE
[PM-1250] Fix gcp rsa encryption

### DIFF
--- a/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
@@ -26,14 +26,14 @@ namespace Bit.KeyConnector.Services
 
         public async Task<byte[]> EncryptAsync(byte[] data)
         {
-            var result = await _keyManagementServiceClient.EncryptAsync(_cryptoKeyName, ByteString.CopyFrom(data));
-            return result.Ciphertext.ToByteArray();
-
+            var publicKey = await this.GetRsaPublicKeyAsync();
+            var result = publicKey.Encrypt(data, RSAEncryptionPadding.OaepSHA256);
+            return result;
         }
 
         public async Task<byte[]> DecryptAsync(byte[] data)
         {
-            var result = await _keyManagementServiceClient.DecryptAsync(_cryptoKeyName, ByteString.CopyFrom(data));
+            var result = await _keyManagementServiceClient.AsymmetricDecryptAsync(_cryptoKeyVersionName, ByteString.CopyFrom(data));
             return result.Plaintext.ToByteArray();
         }
 

--- a/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Google.Cloud.Kms.V1;
@@ -26,7 +26,7 @@ namespace Bit.KeyConnector.Services
 
         public async Task<byte[]> EncryptAsync(byte[] data)
         {
-            var publicKey = await this.GetRsaPublicKeyAsync();
+            var publicKey = await GetRsaPublicKeyAsync();
             var result = publicKey.Encrypt(data, RSAEncryptionPadding.OaepSHA256);
             return result;
         }


### PR DESCRIPTION
Our RSA encryption from GCP were previously using the `EncryptAsync` call on the KMS sdk. This call requires a ENCRYPT_DECRYPT style key, but the key connector requires an RSA key for encrypting the symmetric key.

This changes our encryption method to using the `PublicKey` class provided by Google and encrypting following the method outlined in their [documentation](https://cloud.google.com/kms/docs/encrypt-decrypt-rsa#kms-encrypt-asymmetric-csharp).