### PR TITLE
[PM-1348] Fix AWS expecting symmetric key

### DIFF
--- a/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
+++ b/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Bit.KeyConnector.Exceptions
+{
+    public class InvalidKeyTypeException : Exception
+    {
+        public InvalidKeyTypeException()
+            : base("This type of key cannot perform this action.") { }
+
+        public InvalidKeyTypeException(string message) : base(message) { }
+    }
+}

--- a/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
+++ b/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
@@ -1,12 +1,20 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Bit.KeyConnector.Exceptions
 {
+    [Serializable]
     public class InvalidKeyTypeException : Exception
     {
         public InvalidKeyTypeException()
             : base("This type of key cannot perform this action.") { }
 
         public InvalidKeyTypeException(string message) : base(message) { }
+
+        public InvalidKeyTypeException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        protected InvalidKeyTypeException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
 }

--- a/src/KeyConnector/KeyConnectorSettings.cs
+++ b/src/KeyConnector/KeyConnectorSettings.cs
@@ -57,6 +57,7 @@
             public string AwsAccessKeySecret { get; set; }
             public string AwsRegion { get; set; }
             public string AwsKeyId { get; set; }
+            public bool AwsUseSymmetricEncryption { get; set; }
             // pkcs11
             //      Providers:
             //      yubihsm

--- a/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.KeyManagementService;
 using Amazon.KeyManagementService.Model;
+using Bit.KeyConnector.Exceptions;
 
 namespace Bit.KeyConnector.Services
 {
@@ -55,7 +55,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new Exception("Cannot sign using symmetric key");
+                throw new InvalidKeyTypeException("Cannot sign using symmetric key");
             }
             using var dataStream = new MemoryStream(data);
             var request = new SignRequest
@@ -73,7 +73,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new Exception("Cannot sign using symmetric key");
+                throw new InvalidKeyTypeException("Cannot sign using symmetric key");
             }
             using var dataStream = new MemoryStream(data);
             using var signatureStream = new MemoryStream(data);
@@ -93,7 +93,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new Exception("Cannot retrieve public key of symmetric key");
+                throw new InvalidKeyTypeException("Cannot retrieve public key of symmetric key");
             }
             var request = new GetPublicKeyRequest
             {

--- a/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
@@ -93,7 +93,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new InvalidKeyTypeException("Cannot retrieve public key of symmetric key");
+                throw new InvalidKeyTypeException("Cannot retrieve public key as symmetric keys do not have public keys");
             }
             var request = new GetPublicKeyRequest
             {

--- a/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Amazon;
@@ -54,7 +55,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new System.Exception("Cannot sign using symmetric key");
+                throw new Exception("Cannot sign using symmetric key");
             }
             using var dataStream = new MemoryStream(data);
             var request = new SignRequest
@@ -72,7 +73,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new System.Exception("Cannot sign using symmetric key");
+                throw new Exception("Cannot sign using symmetric key");
             }
             using var dataStream = new MemoryStream(data);
             using var signatureStream = new MemoryStream(data);
@@ -92,7 +93,7 @@ namespace Bit.KeyConnector.Services
         {
             if (_settings.RsaKey.AwsUseSymmetricEncryption)
             {
-                throw new System.Exception("Cannot retrieve public key of symmetric key");
+                throw new Exception("Cannot retrieve public key of symmetric key");
             }
             var request = new GetPublicKeyRequest
             {

--- a/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
@@ -26,7 +26,8 @@ namespace Bit.KeyConnector.Services
             var request = new EncryptRequest
             {
                 KeyId = _settings.RsaKey.AwsKeyId,
-                Plaintext = dataStream
+                Plaintext = dataStream,
+                EncryptionAlgorithm = EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
             };
             var response = await _kmsClient.EncryptAsync(request);
             return response.CiphertextBlob.ToArray();
@@ -38,7 +39,8 @@ namespace Bit.KeyConnector.Services
             var request = new DecryptRequest
             {
                 KeyId = _settings.RsaKey.AwsKeyId,
-                CiphertextBlob = dataStream
+                CiphertextBlob = dataStream,
+                EncryptionAlgorithm = EncryptionAlgorithmSpec.RSAES_OAEP_SHA_256
             };
             var response = await _kmsClient.DecryptAsync(request);
             return response.Plaintext.ToArray();

--- a/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/GoogleCloudKmsRsaKeyService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Google.Cloud.Kms.V1;

--- a/src/KeyConnector/Startup.cs
+++ b/src/KeyConnector/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Security.Claims;
 using Bit.KeyConnector.Repositories;
@@ -54,8 +54,11 @@ namespace Bit.KeyConnector
                 services.AddHostedService<HostedServices.DatabaseMigrationHostedService>();
             }
 
-            services.AddHealthChecks()
-                .AddCheck<RsaHealthCheckService>("RsaHealthCheckService");
+            if (!settings.RsaKey.AwsUseSymmetricEncryption)
+            {
+                services.AddHealthChecks()
+                    .AddCheck<RsaHealthCheckService>("RsaHealthCheckService");
+            }
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, KeyConnectorSettings settings)
@@ -73,9 +76,14 @@ namespace Bit.KeyConnector
             app.UseAuthentication();
             app.UseAuthorization();
 
-            app.UseEndpoints(endpoints => {
+            app.UseEndpoints(endpoints =>
+            {
                 endpoints.MapDefaultControllerRoute();
-                endpoints.MapHealthChecks("~/health").AllowAnonymous();
+
+                if (!settings.RsaKey.AwsUseSymmetricEncryption)
+                {
+                    endpoints.MapHealthChecks("~/health").AllowAnonymous();
+                }
             });
         }
 


### PR DESCRIPTION
Key Connector uses an RSA key as a Key Encryption Key, encrypting a symmetric key for all the data at rest ([envelope encryption](https://cloud.ibm.com/docs/key-protect?topic=key-protect-envelope-encryption#envelope-encryption-overview)).

We previously never specified an `EncryptionAlgorithm` while encrypting/decrypting using AWS. This meant that the KMS client was using the default `SYMMETRIC_DEFAULT` and expecting users to use a symmetric key.

This fixes the AWS key service to use RSA encryption instead, and adds a setting to allow older users to continue using their symmetric key.