### PR TITLE
Update CODEOWNERS for version bump

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,6 @@
 **/.dockerignore @bitwarden/dept-devops
 **/entrypoint.sh @bitwarden/dept-devops
 **/prepare-env.sh @bitwarden/dept-devops
+
+# Multiple owners
+src/KeyConnector/KeyConnector.csproj


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file so that DevOps can approve PRs created by the `Version Bump` workflow.