### PR TITLE
Fix Docker image

### DIFF
--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -2,8 +2,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 LABEL com.bitwarden.product="bitwarden"
 
-RUN apt-get update -y \
+RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        gosu \
         curl \
         libc-dev \
         opensc \
@@ -25,14 +26,8 @@ EXPOSE 5000
 COPY obj/build-output/publish .
 
 COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh 
-
-COPY prepare-env.sh /
-RUN chmod +x /prepare-env.sh && \
-    /prepare-env.sh
+RUN chmod +x /entrypoint.sh
 
 HEALTHCHECK CMD curl -f http://localhost:5000/health || exit 1
-
-USER bitwarden
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/src/KeyConnector/entrypoint.sh
+++ b/src/KeyConnector/entrypoint.sh
@@ -1,6 +1,40 @@
 #!/bin/bash
 
+# Setup
+
+GROUPNAME="bitwarden"
+USERNAME="bitwarden"
+
+LUID=${LOCAL_UID:-0}
+LGID=${LOCAL_GID:-0}
+
+# Step down from host root to well-known nobody/nogroup user
+
+if [ $LUID -eq 0 ]
+then
+    LUID=65534
+fi
+if [ $LGID -eq 0 ]
+then
+    LGID=65534
+fi
+
+# Create user and group
+
+groupadd -o -g $LGID $GROUPNAME >/dev/null 2>&1 ||
+groupmod -o -g $LGID $GROUPNAME >/dev/null 2>&1
+useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
+usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
+mkhomedir_helper $USERNAME
+
+# The rest...
+
+chown -R $USERNAME:$GROUPNAME /app
+mkdir -p /etc/bitwarden/logs
+mkdir -p /etc/bitwarden/ca-certificates
+chown -R $USERNAME:$GROUPNAME /etc/bitwarden
+
 cp /etc/bitwarden/ca-certificates/*.crt /usr/local/share/ca-certificates/ >/dev/null 2>&1 \
     && update-ca-certificates
 
-dotnet /app/KeyConnector.dll
+exec gosu $USERNAME:$GROUPNAME dotnet /app/KeyConnector.dll


### PR DESCRIPTION
This PR changes the `Dockerfile` and `entrypoint.sh` script to use the logic/layout from `v2023.5.0`, but retains some updates like using .NET 6 as a base image.