### PR TITLE
Ignore .NET SDK updates with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,8 +8,9 @@
     ":pinAllExceptPeerDependencies",
     ":prConcurrentLimit10",
     ":rebaseStalePrs",
-    "schedule:weekends",
-    ":separateMajorReleases"
+    ":separateMajorReleases",
+    "group:monorepos",
+    "schedule:weekends"
   ],
   "enabledManagers": ["dockerfile", "github-actions", "nuget"],
   "packageRules": [
@@ -28,5 +29,6 @@
       "matchManagers": ["nuget"],
       "matchUpdateTypes": ["minor", "patch"]
     }
-  ]
+  ],
+  "ignoreDeps": ["dotnet-sdk"]
 }


### PR DESCRIPTION
Ignores the .NET SDK with Renovate since we want to keep it at `.100`.
