### PR TITLE
Docker - Apply fixes for Checkmarkx findings

### DIFF
--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 
 LABEL com.bitwarden.product="bitwarden"
 

--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:6.0
 
 LABEL com.bitwarden.product="bitwarden"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        gosu \
-        curl \
-        libc-dev \
-        opensc \
+        gosu=1.12* \
+        curl=7.74.0* \
+        libc6-dev=2.31* \
+        opensc=0.21.0* \
     && rm -rf /var/lib/apt/lists/*
 
 # Install YubiHSM2 SDK
@@ -17,7 +17,8 @@ RUN curl -O https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-2021-08
     && dpkg -i yubihsm2-sdk/libyubihsm-http1_*_amd64.deb \
     && dpkg -i yubihsm2-sdk/libyubihsm1_*_amd64.deb \
     && dpkg -i yubihsm2-sdk/yubihsm-pkcs11_*_amd64.deb \
-    && apt-get install -f
+    && apt-get install -y -f --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV ASPNETCORE_URLS http://+:5000
 WORKDIR /app


### PR DESCRIPTION
This PR applies fixes for most of the Checkmarkx findings for the `Dockerfile`.  We cannot currently at this time apply the `USER` instruction unless we move the `ca-certificates` feature to a volume mount.