### PR TITLE
[PM-5619] Revert VaultSharp version update to fix HashiCorp cert errors

### DIFF
--- a/src/KeyConnector/KeyConnector.csproj
+++ b/src/KeyConnector/KeyConnector.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1"/>
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
-    <PackageReference Include="VaultSharp" Version="1.13.0.1"/>
+    <PackageReference Include="VaultSharp" Version="1.7.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/KeyConnector/Services/HashicorpVaultCertificateProviderService.cs
+++ b/src/KeyConnector/Services/HashicorpVaultCertificateProviderService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods.Token;
 
@@ -9,10 +10,12 @@ namespace Bit.KeyConnector.Services
     public class HashicorpVaultCertificateProviderService : ICertificateProviderService
     {
         private readonly KeyConnectorSettings _settings;
+        private readonly ILogger<HashicorpVaultCertificateProviderService> _logger;
 
-        public HashicorpVaultCertificateProviderService(KeyConnectorSettings settings)
+        public HashicorpVaultCertificateProviderService(KeyConnectorSettings settings, ILogger<HashicorpVaultCertificateProviderService> logger)
         {
             _settings = settings;
+            _logger = logger;
         }
 
         public async Task<X509Certificate2> GetCertificateAsync()
@@ -32,6 +35,10 @@ namespace Bit.KeyConnector.Services
                 var certData = secret.Data.Data[_settings.Certificate.VaultSecretDataKey] as string;
                 return new X509Certificate2(Convert.FromBase64String(certData),
                     _settings.Certificate.VaultSecretFilePassword);
+            }
+            else
+            {
+                _logger.LogError("No secret found in Hashicorp Vault with key {key}", _settings.Certificate.VaultSecretDataKey);
             }
 
             return null;


### PR DESCRIPTION
In https://github.com/bitwarden/key-connector/pull/95, we updated `VaultSharp` from `1.7.0` to `1.13.0.1`.  Doing so broke the retrieval of certificates from HashiCorp Vault for our Key Connector customers.

After adding debugging logging, we were unable to quickly address the problem.  This PR reverts back to the known working dependency version, and we will need to address the breaking change when we have more time without customers being affected.

In adding (and removing) the debug logging, I added a `ILogger` to the certificate retrieval service, and I elected to keep it in this PR in order to provide for any future logging work, and also to explicitly log an error if there were an issue retrieving the certificate.