### PR TITLE
[PM-6116] Update AWS key service to handle authentication with instance metadata

### DIFF
--- a/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/AwsKmsRsaKeyService.cs
@@ -17,8 +17,7 @@ namespace Bit.KeyConnector.Services
             KeyConnectorSettings settings)
         {
             _settings = settings;
-            _kmsClient = new AmazonKeyManagementServiceClient(settings.RsaKey.AwsAccessKeyId,
-                settings.RsaKey.AwsAccessKeySecret, RegionEndpoint.GetBySystemName(settings.RsaKey.AwsRegion));
+            _kmsClient = new AmazonKeyManagementServiceClient(RegionEndpoint.GetBySystemName(settings.RsaKey.AwsRegion));
         }
 
         public async Task<byte[]> EncryptAsync(byte[] data)


### PR DESCRIPTION
We have a customer who would like to use their Amazon instance metadata for authentication instead of an Id and secret that is configured with environment variables.

To support this, [their documentation](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html) specifies that we should construct the client without passing in the Id and secret.

In this change, we check if **both** the Id and secret are empty, and if so assume that the user wishes to use instance metadata.