### PR TITLE
[PM-9310] Add test project and necessary workflows to use it, with centralized versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,50 +1,27 @@
----
 name: Build
 
 on:
-  push:
-    paths-ignore:
-      - ".github/workflows/**"
   workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "rc"
+      - "hotfix-rc"
+  pull_request:
 
 jobs:
-  cloc:
-    name: CLOC
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Install cloc
-        run: sudo apt update && sudo apt install -y cloc
-
-      - name: Print lines of code
-        run: cloc --include-lang C#,SQL,Razor,"Bourne Shell",PowerShell,HTML,CSS,Sass,JavaScript,TypeScript --vcs git
-
-
   build-artifacts:
     name: Build artifacts
     runs-on: ubuntu-22.04
+
     steps:
-      - name: Checkout repo
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Print environment
-        run: |
-          whoami
-          dotnet --info
-          echo "GitHub ref: $GITHUB_REF"
-          echo "GitHub event: $GITHUB_EVENT"
+      - name: Set up .NET
+        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
-      - name: Restore/Clean service
-        working-directory: src/KeyConnector
-        run: |
-          echo "Restore"
-          dotnet restore
-          echo "Clean"
-          dotnet clean -c "Release" -o obj/build-output/publish
-
-      - name: Publish service
+      - name: Publish project
         working-directory: src/KeyConnector
         run: |
           echo "Publish"
@@ -55,13 +32,12 @@ jobs:
           pwd
           ls -atlh ../../../
 
-      - name: Upload service artifact
+      - name: Upload project artifact
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: KeyConnector.zip
           path: src/KeyConnector/KeyConnector.zip
           if-no-files-found: error
-
 
   build-docker:
     name: Build Docker images
@@ -70,16 +46,17 @@ jobs:
     env:
       _AZ_REGISTRY: bitwardenprod.azurecr.io
       _PROJECT_NAME: key-connector
+
     steps:
-      - name: Checkout repo
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Login to Azure - PROD Subscription
+      - name: Log in to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
-      - name: Login to PROD ACR
+      - name: Log in to ACR
         run: az acr login -n ${_AZ_REGISTRY%.azurecr.io}
 
       - name: Generate Docker image tag
@@ -91,7 +68,7 @@ jobs:
           fi
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Generate image full name
+      - name: Generate full image name
         id: image-name
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
@@ -102,7 +79,7 @@ jobs:
         with:
           name: KeyConnector.zip
 
-      - name: Setup build artifact
+      - name: Set up build artifact
         run: |
           mkdir -p src/KeyConnector/obj/build-output/publish
           unzip KeyConnector.zip -d src/KeyConnector/obj/build-output/publish

--- a/.github/workflows/clean-up-rc-branch.yml
+++ b/.github/workflows/clean-up-rc-branch.yml
@@ -1,5 +1,4 @@
----
-name: Cleanup RC Branch
+name: Clean up RC branch
 
 on:
   push:
@@ -8,10 +7,11 @@ on:
 
 jobs:
   delete-rc:
-    name: Delete RC Branch
+    name: Delete RC branch
     runs-on: ubuntu-22.04
+
     steps:
-      - name: Login to Azure - CI Subscription
+      - name: Log in to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
         with:
           creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
@@ -23,13 +23,13 @@ jobs:
           keyvault: bitwarden-ci
           secrets: "github-pat-bitwarden-devops-bot-repo-scope"
 
-      - name: Checkout main
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
           token: ${{ steps.retrieve-bot-secrets.outputs.github-pat-bitwarden-devops-bot-repo-scope }}
 
-      - name: Check if a RC branch exists
+      - name: Check if RC branch exists
         id: branch-check
         run: |
           hotfix_rc_branch_check=$(git ls-remote --heads origin hotfix-rc | wc -l)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
----
 name: Release
-run-name: Release - ${{ github.event.inputs.release_type }}
+run-name: Release ${{ github.event.inputs.release_type }}
 
 on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release Options'
-        default: 'Initial Release'
+        description: "Release Options"
+        default: "Initial Release"
         type: choice
         options:
           - Initial Release
@@ -21,8 +20,9 @@ jobs:
     outputs:
       release_version: ${{ steps.version.outputs.version }}
       branch-name: ${{ steps.branch.outputs.branch-name }}
+
     steps:
-      - name: Branch check
+      - name: Check branch
         if: ${{ github.event.inputs.release_type != 'Dry Run' }}
         run: |
           if [[ "$GITHUB_REF" != "refs/heads/rc" ]] && [[ "$GITHUB_REF" != "refs/heads/hotfix-rc" ]]; then
@@ -32,16 +32,16 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout repo
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - name: Check Release Version
+      - name: Check release version
         id: version
         uses: bitwarden/gh-actions/release-version-check@main
         with:
           release-type: ${{ github.event.inputs.release_type }}
           project-type: dotnet
-          file: src/KeyConnector/KeyConnector.csproj
+          file: Directory.Build.props
 
       - name: Get branch name
         id: branch
@@ -77,24 +77,17 @@ jobs:
       _RELEASE_VERSION: ${{ needs.setup.outputs.release_version }}
       _BRANCH_NAME: ${{ needs.setup.outputs.branch-name }}
       _RELEASE_OPTION: ${{ github.event.inputs.release_type }}
-    steps:
-      - name: Print environment
-        run: |
-          whoami
-          docker --version
-          echo "GitHub ref: $GITHUB_REF"
-          echo "GitHub event: $GITHUB_EVENT"
-          echo "Github Release Option: $_RELEASE_OPTION"
 
-      - name: Login to Azure - Prod Subscription
+    steps:
+      - name: Log in to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
-      - name: Login to Azure ACR
+      - name: Log in to ACR
         run: az acr login -n ${_AZ_REGISTRY%.azurecr.io}
 
-      - name: Setup DCT
+      - name: Set up DCT
         id: setup-dct
         uses: bitwarden/gh-actions/setup-docker-trust@main
         with:
@@ -139,7 +132,6 @@ jobs:
       - name: Log out of Docker
         run: docker logout
 
-
   check-failures:
     name: Check for failures
     if: always()
@@ -148,16 +140,17 @@ jobs:
       - release-docker
       - release-github
       - setup
+
     steps:
       - name: Check if any job failed
         if: |
           (github.ref == 'refs/heads/main'
           || github.ref == 'refs/heads/rc'
-          || github.ref == 'refs/heads/hotfix')
+          || github.ref == 'refs/heads/hotfix-rc')
           && contains(needs.*.result, 'failure')
         run: exit 1
 
-      - name: Login to Azure - CI subscription
+      - name: Log in to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
         if: failure()
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Test
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  testing:
+  test:
     name: Run tests
     if: ${{ startsWith(github.head_ref, 'version_bump_') == false }}
     runs-on: ubuntu-22.04
@@ -23,14 +23,14 @@ jobs:
         uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
       - name: Test solution
-        run: dotnet test --configuration Debug --logger "trx;LogFileName=oss-test-results.trx" /p:CoverletOutputFormatter="cobertura" --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration Debug --logger "trx;LogFileName=test-results.trx" /p:CoverletOutputFormatter="cobertura" --collect:"XPlat Code Coverage"
 
       - name: Report test results
         uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
         if: always()
         with:
           name: Test Results
-          path: "**/*-test-results.trx"
+          path: "**/test-results.trx"
           reporter: dotnet-trx
           fail-on-error: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Testing
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+      - "rc"
+      - "hotfix-rc"
+  pull_request:
+
+jobs:
+  testing:
+    name: Run tests
+    if: ${{ startsWith(github.head_ref, 'version_bump_') == false }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+
+      - name: Test solution
+        run: dotnet test ./test --configuration Debug --logger "trx;LogFileName=oss-test-results.trx" /p:CoverletOutputFormatter="cobertura" --collect:"XPlat Code Coverage"
+
+      - name: Report test results
+        uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0
+        if: always()
+        with:
+          name: Test Results
+          path: "**/*-test-results.trx"
+          reporter: dotnet-trx
+          fail-on-error: true
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@0cfda1dd0a4ad9efc75517f399d859cd1ea4ced1 # v4.0.2
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
 
       - name: Test solution
-        run: dotnet test ./test --configuration Debug --logger "trx;LogFileName=oss-test-results.trx" /p:CoverletOutputFormatter="cobertura" --collect:"XPlat Code Coverage"
+        run: dotnet test --configuration Debug --logger "trx;LogFileName=oss-test-results.trx" /p:CoverletOutputFormatter="cobertura" --collect:"XPlat Code Coverage"
 
       - name: Report test results
         uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226 # v1.6.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,5 +1,4 @@
----
-name: Version Bump
+name: Bump version
 
 on:
   workflow_dispatch:
@@ -19,10 +18,11 @@ on:
 
 jobs:
   bump_version:
-    name: Bump Version
+    name: Bump version
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.set-final-version-output.outputs.version }}
+
     steps:
       - name: Validate version input
         if: ${{ inputs.version_number_override != '' }}
@@ -30,7 +30,7 @@ jobs:
         with:
           version: ${{ inputs.version_number_override }}
 
-      - name: Slack Notification Check
+      - name: Check for Slack notifications
         run: |
           if [[ "${{ inputs.enable_slack_notification }}" == true ]]; then
             echo "Slack notifications enabled."
@@ -38,7 +38,7 @@ jobs:
             echo "Slack notifications disabled."
           fi
 
-      - name: Checkout Branch
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
@@ -53,7 +53,7 @@ jobs:
             exit 1
           fi
 
-      - name: Login to Azure - CI Subscription
+      - name: Log in to Azure
         uses: Azure/login@e15b166166a8746d1a47596803bd8c1b595455cf # v1.6.0
         with:
           creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
@@ -75,12 +75,12 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Setup git
+      - name: Set up Git
         run: |
           git config --local user.email "106330231+bitwarden-devops-bot@users.noreply.github.com"
           git config --local user.name "bitwarden-devops-bot"
 
-      - name: Create Version Branch
+      - name: Create version branch
         id: create-branch
         run: |
           NAME=version_bump_${{ github.ref_name }}_$(date +"%Y-%m-%d")
@@ -95,7 +95,7 @@ jobs:
       - name: Get current version
         id: current-version
         run: |
-          CURRENT_VERSION=$(xmllint -xpath "/Project/PropertyGroup/Version/text()" src/KeyConnector/KeyConnector.csproj)
+          CURRENT_VERSION=$(xmllint -xpath "/Project/PropertyGroup/Version/text()" Directory.Build.props)
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Verify input version
@@ -126,20 +126,20 @@ jobs:
         with:
           version: ${{ steps.current-version.outputs.version }}
 
-      - name: Bump Version - csproj - Version Override
+      - name: Bump version props for version override
         if: ${{ inputs.version_number_override != '' }}
         id: bump-version-override
         uses: bitwarden/gh-actions/version-bump@main
         with:
-          file_path: "src/KeyConnector/KeyConnector.csproj"
+          file_path: "Directory.Build.props"
           version: ${{ inputs.version_number_override }}
 
-      - name: Bump Version - csproj - Automatic Calculation
+      - name: Bump version props with automatic calculation
         if: ${{ inputs.version_number_override == '' }}
         id: bump-version-automatic
         uses: bitwarden/gh-actions/version-bump@main
         with:
-          file_path: "src/KeyConnector/KeyConnector.csproj"
+          file_path: "Directory.Build.props"
           version: ${{ steps.calculate-next-version.outputs.version }}
 
       - name: Set final version output
@@ -171,7 +171,7 @@ jobs:
           PR_BRANCH: ${{ steps.create-branch.outputs.name }}
         run: git push -u origin $PR_BRANCH
 
-      - name: Create Version PR
+      - name: Create version PR
         if: ${{ steps.version-changed.outputs.changes_to_commit == 'TRUE' }}
         id: create-pr
         env:
@@ -223,8 +223,9 @@ jobs:
     if: ${{ inputs.cut_rc_branch == true }}
     needs: bump_version
     runs-on: ubuntu-22.04
+
     steps:
-      - name: Checkout Branch
+      - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
@@ -242,7 +243,7 @@ jobs:
           while : ; do
             echo "Waiting for version to be updated..."
             git pull --force
-            CURRENT_VERSION=$(xmllint -xpath "/Project/PropertyGroup/Version/text()" src/KeyConnector/KeyConnector.csproj)
+            CURRENT_VERSION=$(xmllint -xpath "/Project/PropertyGroup/Version/text()" Directory.Build.props)
 
             # If the versions don't match we continue the loop, otherwise we break out of the loop.
             [[ "$NEW_VERSION" != "$CURRENT_VERSION" ]] || break

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+
+    <Version>2024.6.0</Version>
+  </PropertyGroup>
+
+</Project>

--- a/bitwarden-key-connector.sln
+++ b/bitwarden-key-connector.sln
@@ -5,6 +5,17 @@ VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyConnector", "src\KeyConnector\KeyConnector.csproj", "{CAD440BF-93C9-4DEC-B083-99FD49B50429}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KeyConnector.Tests", "test\KeyConnector.Tests\KeyConnector.Tests.csproj", "{AA96B804-830F-423C-9542-BC6E841FF637}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C6ABC3D7-FFDB-4376-97E9-263D1CFB8E97}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		LICENSE.txt = LICENSE.txt
+		README.md = README.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +26,10 @@ Global
 		{CAD440BF-93C9-4DEC-B083-99FD49B50429}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CAD440BF-93C9-4DEC-B083-99FD49B50429}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CAD440BF-93C9-4DEC-B083-99FD49B50429}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA96B804-830F-423C-9542-BC6E841FF637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA96B804-830F-423C-9542-BC6E841FF637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA96B804-830F-423C-9542-BC6E841FF637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA96B804-830F-423C-9542-BC6E841FF637}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/KeyConnector/KeyConnector.csproj
+++ b/src/KeyConnector/KeyConnector.csproj
@@ -1,12 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Bit.KeyConnector</RootNamespace>
     <UserSecretsId>bitwarden-KeyConnector</UserSecretsId>
-    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>   
-    
-    <Version>2024.6.0</Version>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/KeyConnector.Tests/KeyConnector.Tests.csproj
+++ b/test/KeyConnector.Tests/KeyConnector.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>KeyConnector.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\KeyConnector\KeyConnector.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/KeyConnector.Tests/ThrowawayTests.cs
+++ b/test/KeyConnector.Tests/ThrowawayTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace KeyConnector.Tests;
+
+public class ThrowawayTests
+{
+    [Fact]
+    public void ThrowawayTests_TestNonsense()
+    {
+        Assert.True(1 == 1);
+    }
+}


### PR DESCRIPTION
Adds a test project so future unit tests can be written. Since this is now the second project in the solution, there's also a move to use `Directory.Build.props` with the versioning centralized there and workflow updates to match.