### PR TITLE
Convert Dockerfile to distroless base image

### DIFF
--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    gosu=1.14* \
     curl=7.88.1* \
     libc6-dev=2.36* \
     opensc=0.23.0* \

--- a/src/KeyConnector/Dockerfile
+++ b/src/KeyConnector/Dockerfile
@@ -1,6 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
-
-LABEL com.bitwarden.product="bitwarden"
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -20,15 +18,20 @@ RUN curl -O https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-2023-11
     && apt-get install -y -f --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless-extra AS final
+
+LABEL com.bitwarden.product="bitwarden"
+
+# Copy the YubiHSM2 SDK libraries and dependencies
+COPY --from=build /usr/lib/x86_64-linux-gnu/* /usr/lib/x86_64-linux-gnu/
+
+USER app
 ENV ASPNETCORE_URLS http://+:5000
 WORKDIR /app
 EXPOSE 5000
 
 COPY obj/build-output/publish .
 
-COPY entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-
 HEALTHCHECK CMD curl -f http://localhost:5000/health || exit 1
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["dotnet", "/app/KeyConnector.dll"]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/VULN-234

## 📔 Objective

This is a first stab at converting some of our docker images to using a more-secure base image which runs rootless and distroless, reducing our attack surface. 

Testing will need to occur on this, due to the integration with YubiHSM having dependencies manually copied over. :crossed_fingers: 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
